### PR TITLE
[codex] Fix Windows Cameo image protocol URLs

### DIFF
--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -140,11 +140,18 @@ export interface ChatImageResolution {
   error: string | null;
 }
 
-/** Build a cross-platform `cameo://` URL for a texture fetch.
+function customProtocolBase(): string {
+  const ua = typeof navigator === "undefined" ? "" : navigator.userAgent;
+  // Tauri serves custom protocols as http://<scheme>.localhost on WebView2.
+  return /\bWindows\b|Android/i.test(ua) ? "http://cameo.localhost" : "cameo://localhost";
+}
+
+/** Build a cross-platform Cameo protocol URL for a texture fetch.
  *
  * Board id lives in the path, not the host: WebView2 represents custom
- * protocols as `http://<scheme>.localhost/...`, so host-based routing breaks
- * on Windows. Relative paths are slash-normalized before per-segment encoding.
+ * protocols as `http://<scheme>.localhost/...`, while macOS uses the native
+ * custom scheme. Relative paths are slash-normalized before per-segment
+ * encoding.
  */
 export function cameoUrl(boardId: string, relPath: string): string {
   const encBoard = encodeURIComponent(boardId);
@@ -153,5 +160,5 @@ export function cameoUrl(boardId: string, relPath: string): string {
     .split("/")
     .map((seg) => encodeURIComponent(seg))
     .join("/");
-  return `cameo://localhost/${encBoard}/${enc}`;
+  return `${customProtocolBase()}/${encBoard}/${enc}`;
 }


### PR DESCRIPTION
## Summary

Fixes image loading on Windows by generating the WebView2-compatible Cameo custom protocol URL shape for workspace images.

## Root cause

Cameo serves canvas/chat images through a custom `cameo` protocol. On Windows, Tauri/WebView2 resolves custom protocol requests through `http://<scheme>.localhost/...`, while the frontend always emitted `cameo://localhost/...`. That mismatch could leave workspace images blank in both the Pixi canvas and chat inline thumbnails because both use the shared `cameoUrl()` helper.

## Changes

- Add a shared custom protocol base helper in `src/lib/ipc.ts`.
- Use `http://cameo.localhost/...` on Windows/Android and keep `cameo://localhost/...` elsewhere.
- Preserve the existing path-scoped board id and per-segment URL encoding behavior.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`

Rust-side checks were not run because `cargo` is not installed in this Windows environment.